### PR TITLE
Don't use caps in output file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 ### `audio2text.py`
 To convert the given `berliner.ogg` file in the test directory to a CSV file
 ```bash
-./audio2text.py -i test/berliner.ogg -o test/berliner -of CSV
+./audio2text.py -i test/berliner.ogg -o test/berliner -of csv
 ```
 
 ### `srtparse.py`


### PR DESCRIPTION
Using a file format in CAPS such as CSV results in the following error: 

``audio2text.py: error: argument -of/--output-format: invalid choice: 'CSV' (choose from 'txt', 'vtt', 'srt', 'csv', 'words')``

Changed the readme so it doesn't display CSV anymore, instead it displays csv. 